### PR TITLE
Add per-user API key support for LLM providers

### DIFF
--- a/bot/handlers/command_handlers.py
+++ b/bot/handlers/command_handlers.py
@@ -34,10 +34,13 @@ logger = logging.getLogger(__name__)
 RECEIPT_IMAGE, CONFIRMATION = range(2)
 
 class CommandHandlers:
-    def __init__(self, memory_storage: MemoryStorage, redis_queue: RedisQueue = None):
+    def __init__(self, memory_storage: MemoryStorage, redis_queue: RedisQueue | None = None):
         self.memory_storage = memory_storage
-        self.ai_service = AIService(StrategyRegistry.get_strategy("deepseek"))
-        self.redis_queue = redis_queue or RedisQueue()
+        self.ai_service = AIService(StrategyRegistry.get_strategy("deepseek"))  # Explicitly declare ai_service
+        if redis_queue is not None:
+            self.redis_queue = redis_queue
+        else:
+            self.redis_queue = RedisQueue()
         # Optionally: track per-user model selection in memory
         self.user_selected_model = {}  # {user_id: provider_name}
 
@@ -45,15 +48,16 @@ class CommandHandlers:
         # --- Analytics logging ---
         user = update.effective_user
         chat = update.effective_chat
-        log_user_event(
-            user_id=user.id if user else None,
-            chat_id=chat.id if chat else None,
-            event_type="help_command",
-            username=getattr(user, "username", None),
-            first_name=getattr(user, "first_name", None),
-            last_name=getattr(user, "last_name", None),
-            llm_name=self.ai_service.get_current_model(),       
-        )
+        if user is not None and chat is not None:
+            log_user_event(
+                user_id=user.id,
+                chat_id=chat.id,
+                event_type="help_command",
+                username=getattr(user, "username", None),
+                first_name=getattr(user, "first_name", None),
+                last_name=getattr(user, "last_name", None),
+                llm_name=self.ai_service.get_current_model(),
+            )
         # --- End analytics logging ---
 
         help_text = (
@@ -82,23 +86,23 @@ class CommandHandlers:
             logger.warning("No message found in update for help_command.")
 
     def _get_user_strategy(self, user_id: int, provider: str):
-        """Return a strategy for the provider, using user key if available."""
-        provider = provider.lower()
-        user_key = get_user_api_key(user_id, provider)
-        if provider == "openai":
-            key = user_key or OpenAIConfig.API_KEY
-            model = OpenAIConfig.MODEL
-            return OpenAIStrategy(key, model)
-        elif provider == "groq":
-            key = user_key or GroqAIConfig.API_KEY
-            model = GroqAIConfig.MODEL
-            return GroqAIStrategy(key, model)
-        elif provider == "deepseek":
-            key = user_key or DeepSeekAIConfig.API_KEY
-            model = DeepSeekAIConfig.MODEL
-            return DeepSeekStrategy(key, model)
-        else:
-            raise ValueError(f"Unknown provider: {provider}")
+            """Return a strategy for the provider, using user key if available."""
+            provider = provider.lower()
+            user_key = get_user_api_key(user_id, provider)
+            if provider == "openai":
+                key = user_key if user_key is not None else (OpenAIConfig.API_KEY if OpenAIConfig.API_KEY is not None else "")
+                model = OpenAIConfig.MODEL if OpenAIConfig.MODEL is not None else ""
+                return OpenAIStrategy(key, model)
+            elif provider == "groq":
+                key = user_key if user_key is not None else (GroqAIConfig.API_KEY if GroqAIConfig.API_KEY is not None else "")
+                model = GroqAIConfig.MODEL if GroqAIConfig.MODEL is not None else ""
+                return GroqAIStrategy(key, model)
+            elif provider == "deepseek":
+                key = user_key if user_key is not None else (DeepSeekAIConfig.API_KEY if DeepSeekAIConfig.API_KEY is not None else "")
+                model = DeepSeekAIConfig.MODEL if DeepSeekAIConfig.MODEL is not None else ""
+                return DeepSeekStrategy(key, model)
+            else:
+                raise ValueError(f"Unknown provider: {provider}")
 
     def _get_user_selected_model(self, user_id: int):
         """Get the user's selected model/provider, or default to 'deepseek'."""
@@ -108,15 +112,16 @@ class CommandHandlers:
         # --- Analytics logging ---
         user = update.effective_user
         chat = update.effective_chat
-        log_user_event(
-            user_id=user.id if user else None,
-            chat_id=chat.id if chat else None,
-            event_type="summarize_command",
-            username=getattr(user, "username", None),
-            first_name=getattr(user, "first_name", None),
-            last_name=getattr(user, "last_name", None),
-            llm_name=self.ai_service.get_current_model(),       
-        )
+        if user is not None and chat is not None:
+            log_user_event(
+                user_id=user.id,
+                chat_id=chat.id,
+                event_type="summarize_command",
+                username=getattr(user, "username", None),
+                first_name=getattr(user, "first_name", None),
+                last_name=getattr(user, "last_name", None),
+                llm_name=self.ai_service.get_current_model(),
+            )
         # --- End analytics logging ---
 
         if not update.effective_chat or not hasattr(update.effective_chat, "id"):
@@ -145,9 +150,9 @@ class CommandHandlers:
             await context.bot.send_message(chat_id=chat_id, text="Summarizing... I'll send the summary here when it's ready! 📝")
 
         # Use user's selected model/provider and key if available
-        provider = self._get_user_selected_model(user.id if user else 0)
+        provider = self._get_user_selected_model(user.id if user is not None else 0)
         try:
-            strategy = self._get_user_strategy(user.id if user else 0, provider)
+            strategy = self._get_user_strategy(user.id if user is not None else 0, provider)
             self.ai_service.set_strategy(strategy)
         except Exception as e:
             logger.error(f"Error setting user strategy: {str(e)}")
@@ -174,15 +179,16 @@ class CommandHandlers:
         # --- Analytics logging ---
         user = update.effective_user
         chat = update.effective_chat
-        log_user_event(
-            user_id=user.id if user else None,
-            chat_id=chat.id if chat else None,
-            event_type="switch_model_command",
-            username=getattr(user, "username", None),
-            first_name=getattr(user, "first_name", None),
-            last_name=getattr(user, "last_name", None),
-            llm_name=self.ai_service.get_current_model(),       
-        )
+        if user is not None and chat is not None:
+            log_user_event(
+                user_id=user.id,
+                chat_id=chat.id,
+                event_type="switch_model_command",
+                username=getattr(user, "username", None),
+                first_name=getattr(user, "first_name", None),
+                last_name=getattr(user, "last_name", None),
+                llm_name=self.ai_service.get_current_model(),
+            )
         # --- End analytics logging ---
 
         # Defensive: check if update.message exists before calling reply_text
@@ -196,7 +202,7 @@ class CommandHandlers:
                 logger.warning("No message or chat found in update for switch_model.")
                 return None
 
-        if not context.args:
+        if not context.args or len(context.args) < 1 or not isinstance(context.args[0], str):
             await safe_reply("Please provide a model name.")
             return
 
@@ -208,12 +214,12 @@ class CommandHandlers:
             return
 
         # Save user model selection
-        if user:
+        if user is not None:
             self.user_selected_model[user.id] = new_model
 
         try:
             # Use user's key if available
-            strategy = self._get_user_strategy(user.id if user else 0, new_model)
+            strategy = self._get_user_strategy(user.id if user is not None else 0, new_model)
             self.ai_service.set_strategy(strategy)
             await safe_reply(f"Model switched to {new_model}")
 
@@ -224,10 +230,10 @@ class CommandHandlers:
     async def set_api_key(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Allow user to set their own API key for a provider."""
         user = update.effective_user
-        if not user:
+        if user is None or update.message is None:
             return
         args = context.args
-        if len(args) != 2:
+        if not args or len(args) != 2:
             await update.message.reply_text("Usage: /set_api_key <provider> <key>")
             return
         provider, key = args
@@ -242,10 +248,10 @@ class CommandHandlers:
     async def clear_api_key(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Allow user to clear their API key for a provider."""
         user = update.effective_user
-        if not user:
+        if user is None or update.message is None:
             return
         args = context.args
-        if len(args) != 1:
+        if not args or len(args) != 1:
             await update.message.reply_text("Usage: /clear_api_key <provider>")
             return
         provider = args[0].lower()
@@ -257,48 +263,48 @@ class CommandHandlers:
         await update.message.reply_text(f"API key for {provider} cleared. The bot will use the default key.")
 
     async def inline_query(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-            """Handle inline queries."""
-            if not hasattr(update, "inline_query") or update.inline_query is None:
-                # Defensive: log and return if inline_query is missing
-                logger.warning("No inline_query found in update for inline_query handler.")
-                return
+        """Handle inline queries."""
+        if not hasattr(update, "inline_query") or update.inline_query is None:
+            # Defensive: log and return if inline_query is missing
+            logger.warning("No inline_query found in update for inline_query handler.")
+            return
 
-            query = getattr(update.inline_query, "query", "")
-            results = [
-                InlineQueryResultArticle(
-                    id=str(uuid4()),
-                    title="Summarize Conversation",
-                    input_message_content=InputTextMessageContent(f"/tldr"),
-                    description="Summarize the conversation in the group chat",
-                ),
-                InlineQueryResultArticle(
-                    id=str(uuid4()),
-                    title="Start",
-                    input_message_content=InputTextMessageContent(f"/start"),
-                    description="Start the bot",
-                ),
-                InlineQueryResultArticle(
-                    id=str(uuid4()),
-                    title="Help",
-                    input_message_content=InputTextMessageContent(f"/help"),
-                    description="Display help information",
-                ),
-            ]
+        query = getattr(update.inline_query, "query", "")
+        results = [
+            InlineQueryResultArticle(
+                id=str(uuid4()),
+                title="Summarize Conversation",
+                input_message_content=InputTextMessageContent(f"/tldr"),
+                description="Summarize the conversation in the group chat",
+            ),
+            InlineQueryResultArticle(
+                id=str(uuid4()),
+                title="Start",
+                input_message_content=InputTextMessageContent(f"/start"),
+                description="Start the bot",
+            ),
+            InlineQueryResultArticle(
+                id=str(uuid4()),
+                title="Help",
+                input_message_content=InputTextMessageContent(f"/help"),
+                description="Display help information",
+            ),
+        ]
 
-            if hasattr(update.inline_query, "answer") and callable(update.inline_query.answer):
-                await update.inline_query.answer(results)
-            else:
-                logger.warning("inline_query.answer is not available on update.inline_query.")
+        if hasattr(update.inline_query, "answer") and callable(update.inline_query.answer):
+            await update.inline_query.answer(results)
+        else:
+            logger.warning("inline_query.answer is not available on update.inline_query.")
 
     @staticmethod
     def _parse_message_count(args, default: int, max_limit: int) -> int:
-            if not args:
-                return default
-            try:
-                count = int(args[0])
-                return min(max(count, 1), max_limit)
-            except ValueError:
-                return default
+        if not args:
+            return default
+        try:
+            count = int(args[0])
+            return min(max(count, 1), max_limit)
+        except ValueError:
+            return default
 
     def _create_summary_prompt(self, text: str) -> str:
         return (f"{text}\nBased on the above, output the following\n\n"
@@ -315,15 +321,16 @@ class CommandHandlers:
         # --- Analytics logging ---
         user = update.effective_user
         chat = update.effective_chat
-        log_user_event(
-            user_id=user.id if user else None,
-            chat_id=chat.id if chat else None,
-            event_type="split_bill_start",
-            username=getattr(user, "username", None),
-            first_name=getattr(user, "first_name", None),
-            last_name=getattr(user, "last_name", None),
-            llm_name=self.ai_service.get_current_model(),       
-        )       
+        if user is not None and chat is not None:
+            log_user_event(
+                user_id=user.id,
+                chat_id=chat.id,
+                event_type="split_bill_start",
+                username=getattr(user, "username", None),
+                first_name=getattr(user, "first_name", None),
+                last_name=getattr(user, "last_name", None),
+                llm_name=self.ai_service.get_current_model(),
+            )
         # --- End analytics logging ---
 
         """
@@ -358,200 +365,200 @@ class CommandHandlers:
         return RECEIPT_IMAGE
 
     async def split_bill_photo_with_context(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-            # Defensive: check if update.message exists before accessing its attributes
-            message = getattr(update, "message", None)
-            if not message or not getattr(message, "photo", None) or not getattr(message, "caption", None):
-                # Defensive: reply in the right place
-                if message and hasattr(message, "reply_text"):
-                    await message.reply_text(
-                        "Please send a *photo of the receipt* with a *caption* describing who paid for what.",
-                        parse_mode="Markdown"
-                    )
-                elif update.effective_chat:
-                    await context.bot.send_message(
-                        chat_id=update.effective_chat.id,
-                        text="Please send a *photo of the receipt* with a *caption* describing who paid for what.",
-                        parse_mode="Markdown"
-                    )
-                return RECEIPT_IMAGE
-
-            photo_file = await message.photo[-1].get_file()
-            image_stream = BytesIO()
-            await photo_file.download_to_memory(image_stream)
-            image_stream.seek(0)
-            image_bytes = image_stream.read()
-            user_context_text = message.caption
-
+        # Defensive: check if update.message exists before accessing its attributes
+        message = getattr(update, "message", None)
+        if not message or not getattr(message, "photo", None) or not getattr(message, "caption", None):
             # Defensive: reply in the right place
-            if hasattr(message, "reply_text"):
-                await message.reply_text("Processing receipt and context...")
-            elif update.effective_chat:
-                await context.bot.send_message(
-                    chat_id=update.effective_chat.id,
-                    text="Processing receipt and context..."
-                )
-
-            # 2. Extract receipt data
-            receipt_data = await extract_receipt_data_from_image(image_bytes)
-            if not receipt_data:
-                if hasattr(message, "reply_text"):
-                    await message.reply_text(
-                        "Sorry, I couldn't extract data from that receipt. Please try again with a clearer image."
-                    )
-                elif update.effective_chat:
-                    await context.bot.send_message(
-                        chat_id=update.effective_chat.id,
-                        text="Sorry, I couldn't extract data from that receipt. Please try again with a clearer image."
-                    )
-                return RECEIPT_IMAGE
-
-            # 3. Parse context and prepare confirmation
-            parsing_result = parse_payment_context_with_llm(
-                user_context_text,
-                receipt_data.items,
-                self.ai_service
-            )
-
-            # Handle parsing errors (returns error message string)
-            if isinstance(parsing_result, str):
-                if hasattr(message, "reply_text"):
-                    await message.reply_text(
-                        f"Context Parsing Failed: {parsing_result}\nPlease try again with a clearer caption."
-                    )
-                elif update.effective_chat:
-                    await context.bot.send_message(
-                        chat_id=update.effective_chat.id,
-                        text=f"Context Parsing Failed: {parsing_result}\nPlease try again with a clearer caption."
-                    )
-                return RECEIPT_IMAGE
-
-            # Unpack parsing results
-            assignments, shared_items, participants = parsing_result
-
-            # Defensive: ensure context.user_data is a dict
-            if not hasattr(context, "user_data") or context.user_data is None:
-                context.user_data = {}
-
-            # Store intermediate data for confirmation
-            context.user_data['bill_split'] = {
-                'receipt_data': receipt_data,
-                'assignments': assignments,
-                'shared_items': shared_items,
-                'participants': participants,
-            }
-
-            # Build confirmation summary
-            lines = ["I've parsed your receipt as follows:"]
-            # Assigned items per person
-            for person, items in assignments.items():
-                item_names = ", ".join(item.name for item in items)
-                lines.append(f"- {person}: {item_names}")
-            # Shared items
-            if shared_items:
-                shared_names = ", ".join(item.name for item in shared_items)
-                lines.append(f"- Shared: {shared_names}")
-            # Participants
-            if participants:
-                parts = ", ".join(participants)
-                lines.append(f"Participants: {parts}")
-            lines.append("\nPlease reply with 'confirm' to finalize the split, or /cancel to abort.")
-
-            # Defensive: reply in the right place
-            if hasattr(message, "reply_text"):
-                await message.reply_text("\n".join(lines))
-            elif update.effective_chat:
-                await context.bot.send_message(
-                    chat_id=update.effective_chat.id,
-                    text="\n".join(lines)
-                )
-            return CONFIRMATION
-
-    async def split_bill_confirm(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-            """
-            Finalize bill split after user confirmation.
-            """
-            # Defensive: ensure context.user_data is a dict
-            if not hasattr(context, "user_data") or context.user_data is None:
-                context.user_data = {}
-
-            data = context.user_data.get('bill_split') if isinstance(context.user_data, dict) else None
-
-            # Defensive: get message object
-            message = getattr(update, "message", None)
-
-            if not data:
-                # Defensive: reply in the right place
-                if message and hasattr(message, "reply_text"):
-                    await message.reply_text(
-                        "No active bill-splitting operation. Please use /splitbill to start."
-                    )
-                elif update.effective_chat:
-                    await context.bot.send_message(
-                        chat_id=update.effective_chat.id,
-                        text="No active bill-splitting operation. Please use /splitbill to start."
-                    )
-                return ConversationHandler.END
-
-            receipt_data = data['receipt_data']
-            assignments = data['assignments']
-            shared_items = data['shared_items']
-            participants = data['participants']
-
-            # Perform calculation
-            split_result = calculate_split(
-                assignments,
-                shared_items,
-                participants,
-                receipt_data.total_amount,
-                receipt_data.service_charge,
-                receipt_data.tax_amount
-            )
-            if isinstance(split_result, str):
-                if message and hasattr(message, "reply_text"):
-                    await message.reply_text(f"Calculation error: {split_result}")
-                elif update.effective_chat:
-                    await context.bot.send_message(
-                        chat_id=update.effective_chat.id,
-                        text=f"Calculation error: {split_result}"
-                    )
-                if isinstance(context.user_data, dict):
-                    context.user_data.pop('bill_split', None)
-                return ConversationHandler.END
-
-            # Format and send final results
-            final_message = format_split_results(
-                split_result,
-                receipt_data.total_amount,
-                receipt_data.service_charge,
-                receipt_data.tax_amount
-            )
             if message and hasattr(message, "reply_text"):
-                await message.reply_text(final_message, parse_mode="Markdown")
-            elif update.effective_chat:
-                await context.bot.send_message(
-                    chat_id=update.effective_chat.id,
-                    text=final_message,
+                await message.reply_text(
+                    "Please send a *photo of the receipt* with a *caption* describing who paid for what.",
                     parse_mode="Markdown"
                 )
-            # Clean up
+            elif update.effective_chat:
+                await context.bot.send_message(
+                    chat_id=update.effective_chat.id,
+                    text="Please send a *photo of the receipt* with a *caption* describing who paid for what.",
+                    parse_mode="Markdown"
+                )
+            return RECEIPT_IMAGE
+
+        photo_file = await message.photo[-1].get_file()
+        image_stream = BytesIO()
+        await photo_file.download_to_memory(image_stream)
+        image_stream.seek(0)
+        image_bytes = image_stream.read()
+        user_context_text = message.caption
+
+        # Defensive: reply in the right place
+        if hasattr(message, "reply_text"):
+            await message.reply_text("Processing receipt and context...")
+        elif update.effective_chat:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text="Processing receipt and context..."
+            )
+
+        # 2. Extract receipt data
+        receipt_data = await extract_receipt_data_from_image(image_bytes)
+        if not receipt_data:
+            if hasattr(message, "reply_text"):
+                await message.reply_text(
+                    "Sorry, I couldn't extract data from that receipt. Please try again with a clearer image."
+                )
+            elif update.effective_chat:
+                await context.bot.send_message(
+                    chat_id=update.effective_chat.id,
+                    text="Sorry, I couldn't extract data from that receipt. Please try again with a clearer image."
+                )
+            return RECEIPT_IMAGE
+
+        # 3. Parse context and prepare confirmation
+        parsing_result = parse_payment_context_with_llm(
+            user_context_text,
+            receipt_data.items,
+            self.ai_service
+        )
+
+        # Handle parsing errors (returns error message string)
+        if isinstance(parsing_result, str):
+            if hasattr(message, "reply_text"):
+                await message.reply_text(
+                    f"Context Parsing Failed: {parsing_result}\nPlease try again with a clearer caption."
+                )
+            elif update.effective_chat:
+                await context.bot.send_message(
+                    chat_id=update.effective_chat.id,
+                    text=f"Context Parsing Failed: {parsing_result}\nPlease try again with a clearer caption."
+                )
+            return RECEIPT_IMAGE
+
+        # Unpack parsing results
+        assignments, shared_items, participants = parsing_result
+
+        # Defensive: ensure context.user_data is a dict
+        if not hasattr(context, "user_data") or context.user_data is None:
+            context.user_data = {}
+
+        # Store intermediate data for confirmation
+        context.user_data['bill_split'] = {
+            'receipt_data': receipt_data,
+            'assignments': assignments,
+            'shared_items': shared_items,
+            'participants': participants,
+        }
+
+        # Build confirmation summary
+        lines = ["I've parsed your receipt as follows:"]
+        # Assigned items per person
+        for person, items in assignments.items():
+            item_names = ", ".join(item.name for item in items)
+            lines.append(f"- {person}: {item_names}")
+        # Shared items
+        if shared_items:
+            shared_names = ", ".join(item.name for item in shared_items)
+            lines.append(f"- Shared: {shared_names}")
+        # Participants
+        if participants:
+            parts = ", ".join(participants)
+            lines.append(f"Participants: {parts}")
+        lines.append("\nPlease reply with 'confirm' to finalize the split, or /cancel to abort.")
+
+        # Defensive: reply in the right place
+        if hasattr(message, "reply_text"):
+            await message.reply_text("\n".join(lines))
+        elif update.effective_chat:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text="\n".join(lines)
+            )
+        return CONFIRMATION
+
+    async def split_bill_confirm(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """
+        Finalize bill split after user confirmation.
+        """
+        # Defensive: ensure context.user_data is a dict
+        if not hasattr(context, "user_data") or context.user_data is None:
+            context.user_data = {}
+
+        data = context.user_data.get('bill_split') if isinstance(context.user_data, dict) else None
+
+        # Defensive: get message object
+        message = getattr(update, "message", None)
+
+        if not data:
+            # Defensive: reply in the right place
+            if message and hasattr(message, "reply_text"):
+                await message.reply_text(
+                    "No active bill-splitting operation. Please use /splitbill to start."
+                )
+            elif update.effective_chat:
+                await context.bot.send_message(
+                    chat_id=update.effective_chat.id,
+                    text="No active bill-splitting operation. Please use /splitbill to start."
+                )
+            return ConversationHandler.END
+
+        receipt_data = data['receipt_data']
+        assignments = data['assignments']
+        shared_items = data['shared_items']
+        participants = data['participants']
+
+        # Perform calculation
+        split_result = calculate_split(
+            assignments,
+            shared_items,
+            participants,
+            receipt_data.total_amount,
+            receipt_data.service_charge,
+            receipt_data.tax_amount
+        )
+        if isinstance(split_result, str):
+            if message and hasattr(message, "reply_text"):
+                await message.reply_text(f"Calculation error: {split_result}")
+            elif update.effective_chat:
+                await context.bot.send_message(
+                    chat_id=update.effective_chat.id,
+                    text=f"Calculation error: {split_result}"
+                )
             if isinstance(context.user_data, dict):
                 context.user_data.pop('bill_split', None)
             return ConversationHandler.END
 
+        # Format and send final results
+        final_message = format_split_results(
+            split_result,
+            receipt_data.total_amount,
+            receipt_data.service_charge,
+            receipt_data.tax_amount
+        )
+        if message and hasattr(message, "reply_text"):
+            await message.reply_text(final_message, parse_mode="Markdown")
+        elif update.effective_chat:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text=final_message,
+                parse_mode="Markdown"
+            )
+        # Clean up
+        if isinstance(context.user_data, dict):
+            context.user_data.pop('bill_split', None)
+        return ConversationHandler.END
+
     async def split_bill_cancel(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-            """
-            Cancel the bill-splitting flow.
-            """
-            # Optionally clean up any stored data
-            if hasattr(context, "user_data") and isinstance(context.user_data, dict):
-                context.user_data.pop('bill_split', None)
-            # Defensive: reply in the right place
-            message = getattr(update, "message", None)
-            if message and hasattr(message, "reply_text"):
-                await message.reply_text("Bill splitting cancelled.")
-            elif update.effective_chat:
-                await context.bot.send_message(
-                    chat_id=update.effective_chat.id,
-                    text="Bill splitting cancelled."
-                )
-            return ConversationHandler.END
+        """
+        Cancel the bill-splitting flow.
+        """
+        # Optionally clean up any stored data
+        if hasattr(context, "user_data") and isinstance(context.user_data, dict):
+            context.user_data.pop('bill_split', None)
+        # Defensive: reply in the right place
+        message = getattr(update, "message", None)
+        if message and hasattr(message, "reply_text"):
+            await message.reply_text("Bill splitting cancelled.")
+        elif update.effective_chat:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text="Bill splitting cancelled."
+            )
+        return ConversationHandler.END

--- a/bot/main.py
+++ b/bot/main.py
@@ -61,6 +61,8 @@ class Bot:
             application.add_handler(CommandHandler("tldr", self.command_handlers.summarize))
             application.add_handler(CommandHandler("dl", self.telegram_service.download_tiktok))
             application.add_handler(CommandHandler("switch_model", self.command_handlers.switch_model))
+            application.add_handler(CommandHandler("set_api_key", self.command_handlers.set_api_key))
+            application.add_handler(CommandHandler("clear_api_key", self.command_handlers.clear_api_key))
             # Bill splitting conversation (receipt + confirmation)
             split_conv = ConversationHandler(
                 entry_points=[CommandHandler("splitbill", self.command_handlers.split_bill_start)],
@@ -105,6 +107,8 @@ class Bot:
             BotCommand("splitbill", "Split bill from receipt"),
             BotCommand("dl", "Download TikTok videos"),
             BotCommand("switch_model", "Switch AI model (QA/Summary)"),
+            BotCommand("set_api_key", "Set your own API key for a provider"),
+            BotCommand("clear_api_key", "Remove your API key for a provider"),
             BotCommand("cancel", "Cancel current operation (like bill split)"),
         ]
         await application.bot.set_my_commands(commands)

--- a/bot/main.py
+++ b/bot/main.py
@@ -146,7 +146,6 @@ class Bot:
     async def _llm_worker(self, application):
         """Background worker to process LLM jobs from Redis queue."""
         from telegram.constants import ParseMode
-        ai_service = self.command_handlers.ai_service
         while True:
             job = await self.redis_queue.dequeue(timeout=5)
             if not job:
@@ -159,7 +158,8 @@ class Bot:
                 user_name = job.get("user_id", "User")
                 original_messages = job.get("original_messages", [])
                 try:
-                    response = ai_service.get_response(prompt)
+                    # Always use the latest ai_service (strategy may change per user)
+                    response = self.command_handlers.ai_service.get_response(prompt)
                     formatted_summary = self.command_handlers._format_summary(str(response), user_name, num_messages)
                     await application.bot.send_message(
                         chat_id=chat_id,

--- a/bot/utils/user/user_api_keys.py
+++ b/bot/utils/user/user_api_keys.py
@@ -1,0 +1,28 @@
+# Simple in-memory user API key storage for BYOK (Bring Your Own Key) LLM support.
+# This can be replaced with persistent storage (e.g., Redis, DB) if needed.
+
+from typing import Dict, Optional
+
+# Structure: {user_id: {provider: api_key}}
+_user_api_keys: Dict[int, Dict[str, str]] = {}
+
+def set_user_api_key(user_id: int, provider: str, api_key: str) -> None:
+    """Set or update the API key for a user and provider."""
+    if user_id not in _user_api_keys:
+        _user_api_keys[user_id] = {}
+    _user_api_keys[user_id][provider.lower()] = api_key
+
+def get_user_api_key(user_id: int, provider: str) -> Optional[str]:
+    """Retrieve the API key for a user and provider, or None if not set."""
+    return _user_api_keys.get(user_id, {}).get(provider.lower())
+
+def clear_user_api_key(user_id: int, provider: str) -> None:
+    """Remove a user's API key for a provider."""
+    if user_id in _user_api_keys:
+        _user_api_keys[user_id].pop(provider.lower(), None)
+        if not _user_api_keys[user_id]:
+            _user_api_keys.pop(user_id)
+
+def get_all_user_keys(user_id: int) -> Dict[str, str]:
+    """Get all provider keys for a user."""
+    return dict(_user_api_keys.get(user_id, {}))


### PR DESCRIPTION
Users can now set or clear their own API keys for OpenAI, Groq, or DeepSeek using /set_api_key and /clear_api_key commands. Model selection and API key usage are tracked per user in memory.