### PR TITLE
Switch bill splitting OCR to GPT-4o

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A powerful Telegram bot that enhances group productivity through AI-powered conv
 
 5. **Bill Splitting System**
    - **Receipt Processing Pipeline**:
-     - OCR using Mistral AI for text extraction
+     - OCR using OpenAI GPT-4o for text extraction
      - AI-powered receipt data structuring
      - Pydantic models for data validation
 
@@ -111,14 +111,13 @@ A powerful Telegram bot that enhances group productivity through AI-powered conv
 
    # Optional (based on AI models you want to use)
    OPENAI_API_KEY=your_openai_key
-   OPENAI_MODEL=gpt-4o-mini  # Optional, defaults to gpt-4o-mini
+   OPENAI_MODEL=gpt-4o  # Optional, defaults to gpt-4o
    GROQ_API_KEY=your_groq_key
    GROQ_MODEL=llama3-8b-8192  # Optional, defaults to llama3-8b-8192
    DEEPSEEK_API_KEY=your_deepseek_key
    DEEPSEEK_MODEL=deepseek-chat  # Optional, defaults to deepseek-chat
 
-   # Required
-   MISTRAL_API_KEY=your_mistral_key # For OCR in the bill splitting feature
+   # Optional
 
    # Optional (for webhook deployment)
    WEBHOOK_URL=your_webhook_url
@@ -157,7 +156,7 @@ A powerful Telegram bot that enhances group productivity through AI-powered conv
 
 ### Model Switching
 Available models:
-- `openai` - OpenAI's GPT models (default: gpt-4o-mini)
+- `openai` - OpenAI's GPT models (default: gpt-4o)
 - `groq` - Groq's Llama 3 (default: llama3-8b-8192)
 - `deepseek` - DeepSeek models (default: deepseek-chat)
 
@@ -308,7 +307,6 @@ BOT_TOKEN=your_telegram_bot_token
 OPENAI_API_KEY=your_openai_key
 GROQ_API_KEY=your_groq_key
 DEEPSEEK_API_KEY=your_deepseek_key
-MISTRAL_API_KEY=your_mistral_key
 WEBHOOK_URL=your_webhook_url
 PORT=your_port
 REDIS_URL=redis://<host>:<port>/<db>

--- a/architecture.md
+++ b/architecture.md
@@ -129,7 +129,7 @@ classDiagram
 
 - **Receipt Processing Pipeline**:
     - Receives image uploads.
-    - Uses OCR (Mistral or AI) to extract text.
+    - Uses OCR (OpenAI GPT-4o) to extract text.
     - Parses payment context using LLM.
     - Calculates and formats split results.
 - Interactive confirmation flow with users.

--- a/bot/config/settings.py
+++ b/bot/config/settings.py
@@ -18,7 +18,7 @@ class TelegramConfig:
 @dataclass
 class OpenAIConfig:
     API_KEY: str | None = os.environ.get("OPENAI_API_KEY")
-    MODEL: str | None = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+    MODEL: str | None = os.environ.get("OPENAI_MODEL", "gpt-4o")
 
 @dataclass
 class GroqAIConfig:

--- a/bot/main.py
+++ b/bot/main.py
@@ -75,6 +75,10 @@ class Bot:
                                        self.command_handlers.split_bill_confirm),
                         MessageHandler(filters.Regex("(?i)^(cancel|no)$"),
                                        self.command_handlers.split_bill_cancel),
+                        MessageHandler(
+                            filters.PHOTO & filters.Caption(),
+                            self.command_handlers.split_bill_photo_with_context,
+                        ),
                     ],
                 },
                 fallbacks=[CommandHandler("cancel", self.command_handlers.split_bill_cancel)],


### PR DESCRIPTION
## Summary
- parse receipts using OpenAI GPT‑4o instead of Mistral
- notify the user about the model being used
- allow resending an image during bill-split confirmation
- default OpenAI model to `gpt-4o`
- update docs

## Testing
- `python -m py_compile bot/services/bill_splitter.py bot/handlers/command_handlers.py bot/main.py bot/config/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_68541dc97538832982b6d80b859178bc