### PR TITLE
Add selectable OpenAI models for bill splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ A powerful Telegram bot that enhances group productivity through AI-powered conv
 
    # Optional (based on AI models you want to use)
    OPENAI_API_KEY=your_openai_key
-   OPENAI_MODEL=gpt-4o  # Optional, defaults to gpt-4o
+   OPENAI_MINI_MODEL=gpt-4o-mini  # Optional, defaults to gpt-4o-mini
+   OPENAI_4O_MODEL=gpt-4o        # Optional
+   OPENAI_41_MODEL=gpt-4-turbo   # Optional
    GROQ_API_KEY=your_groq_key
    GROQ_MODEL=llama3-8b-8192  # Optional, defaults to llama3-8b-8192
    DEEPSEEK_API_KEY=your_deepseek_key
@@ -156,7 +158,9 @@ A powerful Telegram bot that enhances group productivity through AI-powered conv
 
 ### Model Switching
 Available models:
-- `openai` - OpenAI's GPT models (default: gpt-4o)
+- `openai-mini` - GPT-4o mini (default)
+- `openai-4o` - GPT-4o
+- `openai-4.1` - GPT-4.1 (turbo)
 - `groq` - Groq's Llama 3 (default: llama3-8b-8192)
 - `deepseek` - DeepSeek models (default: deepseek-chat)
 

--- a/bot/config/settings.py
+++ b/bot/config/settings.py
@@ -18,7 +18,9 @@ class TelegramConfig:
 @dataclass
 class OpenAIConfig:
     API_KEY: str | None = os.environ.get("OPENAI_API_KEY")
-    MODEL: str | None = os.environ.get("OPENAI_MODEL", "gpt-4o")
+    MINI_MODEL: str = os.environ.get("OPENAI_MINI_MODEL", "gpt-4o-mini")
+    O4_MODEL: str = os.environ.get("OPENAI_4O_MODEL", "gpt-4o")
+    FOUR_ONE_MODEL: str = os.environ.get("OPENAI_41_MODEL", "gpt-4-turbo")
 
 @dataclass
 class GroqAIConfig:

--- a/bot/main.py
+++ b/bot/main.py
@@ -64,6 +64,7 @@ class Bot:
             application.add_handler(CommandHandler("set_api_key", self.command_handlers.set_api_key))
             application.add_handler(CommandHandler("clear_api_key", self.command_handlers.clear_api_key))
             application.add_handler(CommandHandler("list_providers", self.command_handlers.list_providers))
+            application.add_handler(CommandHandler("set_receipt_model", self.command_handlers.set_receipt_model))
             # Bill splitting conversation (receipt + confirmation)
             split_conv = ConversationHandler(
                 entry_points=[CommandHandler("splitbill", self.command_handlers.split_bill_start)],
@@ -111,6 +112,7 @@ class Bot:
             BotCommand("set_api_key", "Set your own API key for a provider"),
             BotCommand("clear_api_key", "Remove your API key for a provider"),
             BotCommand("list_providers", "List all valid provider names"),
+            BotCommand("set_receipt_model", "Choose OpenAI model for receipts"),
             BotCommand("cancel", "Cancel current operation (like bill split)"),
         ]
         await application.bot.set_my_commands(commands)

--- a/bot/services/ai/__init__.py
+++ b/bot/services/ai/__init__.py
@@ -25,7 +25,8 @@ class StrategyRegistry:
 
 # Register strategies with their respective API keys and models
 api_key = OpenAIConfig.API_KEY or ""
-model = OpenAIConfig.MODEL or ""
-StrategyRegistry.register_strategy("openai", OpenAIStrategy(api_key, model))
+StrategyRegistry.register_strategy("openai-mini", OpenAIStrategy(api_key, OpenAIConfig.MINI_MODEL))
+StrategyRegistry.register_strategy("openai-4o", OpenAIStrategy(api_key, OpenAIConfig.O4_MODEL))
+StrategyRegistry.register_strategy("openai-4.1", OpenAIStrategy(api_key, OpenAIConfig.FOUR_ONE_MODEL))
 StrategyRegistry.register_strategy("groq", GroqAIStrategy(GroqAIConfig.API_KEY or "", GroqAIConfig.MODEL or ""))
 StrategyRegistry.register_strategy("deepseek", DeepSeekStrategy(DeepSeekAIConfig.API_KEY or "", DeepSeekAIConfig.MODEL or ""))

--- a/bot/services/bill_splitter.py
+++ b/bot/services/bill_splitter.py
@@ -56,15 +56,16 @@ class ContextParsingResult(BaseModel):
 
 
 # --- AI Extraction Logic ---
-async def extract_receipt_data_from_image(image_bytes: bytes) -> ReceiptData | None:
-    """Use OpenAI GPT-4o to parse the receipt image into ``ReceiptData``."""
+async def extract_receipt_data_from_image(image_bytes: bytes, model_name: str | None = None) -> ReceiptData | None:
+    """Use OpenAI to parse the receipt image into ``ReceiptData``."""
 
     openai_api_key = os.getenv("OPENAI_API_KEY")
     if not openai_api_key:
         logger.error("OpenAI API key is not configured (OPENAI_API_KEY).")
         return None
 
-    model_name = os.getenv("OPENAI_MODEL", "gpt-4o")
+    if model_name is None:
+        model_name = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
     client = OpenAI(api_key=openai_api_key)
 
     try:


### PR DESCRIPTION
## Summary
- support multiple OpenAI models via StrategyRegistry
- default OpenAI model changed back to `gpt-4o-mini`
- allow users to pick a model for receipt parsing with `/set_receipt_model`
- update bill splitting flow to use the chosen model
- document new environment variables and models

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685424c227f48329a8809ddffabe3b63