### PR TITLE
Change default GPT-4 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ A powerful Telegram bot that enhances group productivity through AI-powered conv
    OPENAI_API_KEY=your_openai_key
    OPENAI_MINI_MODEL=gpt-4o-mini  # Optional, defaults to gpt-4o-mini
    OPENAI_4O_MODEL=gpt-4o        # Optional
-   OPENAI_41_MODEL=gpt-4-turbo   # Optional
+   OPENAI_41_MODEL=gpt-4.1       # Optional
    GROQ_API_KEY=your_groq_key
    GROQ_MODEL=llama3-8b-8192  # Optional, defaults to llama3-8b-8192
    DEEPSEEK_API_KEY=your_deepseek_key

--- a/bot/config/settings.py
+++ b/bot/config/settings.py
@@ -20,7 +20,7 @@ class OpenAIConfig:
     API_KEY: str | None = os.environ.get("OPENAI_API_KEY")
     MINI_MODEL: str = os.environ.get("OPENAI_MINI_MODEL", "gpt-4o-mini")
     O4_MODEL: str = os.environ.get("OPENAI_4O_MODEL", "gpt-4o")
-    FOUR_ONE_MODEL: str = os.environ.get("OPENAI_41_MODEL", "gpt-4-turbo")
+    FOUR_ONE_MODEL: str = os.environ.get("OPENAI_41_MODEL", "gpt-4.1")
 
 @dataclass
 class GroqAIConfig:


### PR DESCRIPTION
## Summary
- change OpenAI GPT 4.1 model default
- update README to reference `gpt-4.1`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685428fdfe88832985a7308ab8731cc7